### PR TITLE
Initialize project scaffolding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master, work ]
+  pull_request:
+    branches: [ main, master, work ]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r backend/requirements.txt
+      - name: Lint
+        run: python -m py_compile backend/main.py
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: |
+          cd frontend
+          npm install
+      - name: Build
+        run: |
+          cd frontend
+          npm run build --if-present
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Node
+node_modules/
+package-lock.json
+
+# Python
+__pycache__/
+
+# Builds
+frontend/build/
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
+# Glanceable Dashboard
+
+This repository contains the starting point for the **Glanceable Dashboard** candidate exercise. The goal is to deliver a home page that summarizes key metrics and AI‑driven insights for Glanceable users.
+
+## Project Structure
+
+- `frontend/` – React + TypeScript application using `react-hook-form` and Nivo charts.
+- `backend/` – Python FastAPI service exposing REST APIs.
+
+## Requirements
+
+- **Node.js** `>=18` and **npm** for the React client.
+- **Python** `>=3.11` for the FastAPI service.
+
+## Running Locally
+
+### Frontend
+```bash
+cd frontend
+npm install
+npm start
+```
+This launches the React development server on <http://localhost:3000>.
+
+### Backend
+```bash
+cd backend
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+The API server will be available at <http://localhost:8000>.
+
+## Deployment Strategy
+
+The app can be deployed with free‑tier services:
+
+- **Frontend** – Vercel is recommended. Run `npm run build` and deploy the output directory.
+- **Backend** – Any Python‑compatible cloud (Render, Railway, etc.) can host the FastAPI app. A small instance using a free plan is sufficient.
+- **Database** – Options include MongoDB Atlas or ElephantSQL free tiers. Configure connection credentials using environment variables in both the backend and deployment service.
+
+## Continuous Integration
+
+GitHub Actions run basic checks for both parts of the project. See `.github/workflows/ci.yml` for details.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,10 @@
+# Backend
+
+This directory contains a Python FastAPI server providing REST endpoints.
+
+Install dependencies and run locally:
+
+```bash
+pip install -r requirements.txt
+uvicorn main:app --reload
+```

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Glanceable Backend"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,10 @@
+# Frontend
+
+This directory contains the React + TypeScript client for the Glanceable Dashboard.
+
+Install dependencies and start development server:
+
+```bash
+npm install
+npm start
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "glanceable-dashboard-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-hook-form": "^7.0.0",
+    "@nivo/bar": "^0.79.0",
+    "@nivo/pie": "^0.79.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.0.0",
+    "react-scripts": "5.0.1"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Glanceable Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+export const App = () => {
+  return <div>Glanceable Dashboard</div>;
+};
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(<App />);


### PR DESCRIPTION
## Summary
- add overview of the Glanceable Dashboard
- create frontend and backend directories with starter files
- document how to run both services locally
- explain deployment choices
- set up GitHub Actions CI

## Testing
- `python -m py_compile backend/main.py`
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863f1939774832c83572d56ecf95a90